### PR TITLE
Implement "Non-Zero Balances" Switch in Account

### DIFF
--- a/frontend/pages/home/components/AssetsList.tsx
+++ b/frontend/pages/home/components/AssetsList.tsx
@@ -64,9 +64,7 @@ const AssetsList = () => {
                 className={`flex flex-row w-9 h-4 rounded-full relative cursor-pointer items-center ${
                   zeroBalance ? "bg-[#26A17B]" : "bg-[#7E7D91]"
                 }`}
-                onClick={() => {
-                  setZeroBalance(!zeroBalance);
-                }}
+                onClick={handleFilterNonZeroBalances}
               >
                 <div
                   className={`w-3 h-3 rounded-full bg-white transition-spacing duration-300 ${
@@ -155,6 +153,12 @@ const AssetsList = () => {
       </div>
     </Fragment>
   );
+
+  function handleFilterNonZeroBalances() {
+    const value = !zeroBalance;
+    localStorage.setItem("enableZeroBalance", JSON.stringify(value));
+    setZeroBalance(value);
+  }
 
   function setSearch(e: ChangeEvent<HTMLInputElement>) {
     if (protocol === ProtocolTypeEnum.Enum.HPL) {

--- a/frontend/pages/hooks/hplHook.tsx
+++ b/frontend/pages/hooks/hplHook.tsx
@@ -38,7 +38,6 @@ export const useHPL = (open: boolean) => {
   const [subInfoType, setSubInfoType] = useState<SubaccountInfo>(SubaccountInfoEnum.Enum.VIRTUALS);
   const [selAsset, setSelAsset] = useState<HPLAsset | undefined>();
   const [editedFt, setEditedFt] = useState<HPLAsset | undefined>();
-  const [zeroBalance, setZeroBalance] = useState(false);
   const [searchKeyHPL, setSearchKeyHPL] = useState("");
   const [expiration, setExpiration] = useState(true);
   const [newVt, setNewVt] = useState<HPLVirtualSubAcc>({
@@ -60,6 +59,12 @@ export const useHPL = (open: boolean) => {
     ft: "-1",
     virtuals: [],
   });
+
+  let enableZeroBalance = false;
+  if (localStorage.getItem("enableZeroBalance") !== null) {
+    enableZeroBalance = JSON.parse(localStorage.getItem("enableZeroBalance") ?? "");
+  }
+  const [zeroBalance, setZeroBalance] = useState(enableZeroBalance);
 
   const setSelSub = (sub: HPLSubAccount | undefined) => {
     dispatch(setHPLSelectedSub(sub));


### PR DESCRIPTION
I just stored the filter state to keep the state of the switch unchanged when the user navigate through the application.